### PR TITLE
Py3 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Hence Jukestapose was born!
 
 ## Dependencies
 
+* Requires python3
 * run the following command: `pip install -r REQUIREMENTS.txt`
 
 ## Usage

--- a/webserver.py
+++ b/webserver.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from flask import Flask
 from flask import request


### PR DESCRIPTION
Python3 was not explicitly listed as a requirement in the docs/codebase. This change will list it.